### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,11 @@ runs:
         restore-keys: ${{ inputs.cache-prefix }}${{ runner.os }}-jdk${{ inputs.java-version }}-${{ inputs.java-distribution }}-maven${{ inputs.maven-version }}-
 
     - name: Installed Maven version
-      run:  echo "version=$(mvn -q -v)" >> $GITHUB_OUTPUT
+      run: |
+        version_info=$(mvn -q -v)
+        echo "version<<EOF" >> $GITHUB_OUTPUT
+        echo $version_info >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
       shell: bash
       id: current-maven
 


### PR DESCRIPTION
To  fix following error message 

<img width="617" alt="Screenshot 2024-01-05 at 9 25 10 PM" src="https://github.com/kamleshbiloniya/setup-maven-action/assets/28893058/7381acb2-abe6-4672-81bb-df22f008a756">

w.r.t github's announcement 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/